### PR TITLE
Correct a CLI display typo

### DIFF
--- a/python/examples/hello_spot/hello_spot.py
+++ b/python/examples/hello_spot/hello_spot.py
@@ -178,7 +178,7 @@ def main(argv):
     bosdyn.client.util.add_base_arguments(parser)
     parser.add_argument(
         '-s', '--save', action='store_true', help=
-        'Save the image captured by Spot to the working directory. To chose the save location, use --save_path instead.'
+        'Save the image captured by Spot to the working directory. To choose the save location, use --save_path instead.'
     )
     parser.add_argument(
         '--save-path', default=None, nargs='?', help=


### PR DESCRIPTION
This PR simply corrects a small typo in the Hello Spot example CLI. Cheers for the Spot SDK! 🍻