### PR TITLE
Update arm_grasp.py

### DIFF
--- a/python/examples/arm_grasp/arm_grasp.py
+++ b/python/examples/arm_grasp/arm_grasp.py
@@ -95,7 +95,7 @@ def arm_object_grasp(config):
             dtype = np.uint16
         else:
             dtype = np.uint8
-        img = np.fromstring(image.shot.image.data, dtype=dtype)
+        img = np.frombuffer(image.shot.image.data, dtype=dtype)
         if image.shot.image.format == image_pb2.Image.FORMAT_RAW:
             img = img.reshape(image.shot.image.rows, image.shot.image.cols)
         else:


### PR DESCRIPTION
Numpy - `fromstring` is deprecated, `frombuffer` as drop-in replacement

Numpy warns:
```
DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on    unicode inputs. Use frombuffer instead
```

`frombuffer` seems to work without issue.