### PR TITLE
Catch gRPC Deserialize error. It occurs when there are many requests in Core I/O

### DIFF
--- a/python/bosdyn-client/src/bosdyn/client/channel.py
+++ b/python/bosdyn-client/src/bosdyn/client/channel.py
@@ -11,11 +11,11 @@ import grpc
 
 from .exceptions import (ClientCancelledOperationError, InvalidClientCertificateError,
                          NonexistentAuthorityError, NotFoundError, PermissionDeniedError,
-                         ProxyConnectionError, ResponseTooLargeError, RetryableUnavailableError,
-                         RpcError, ServiceFailedDuringExecutionError, ServiceUnavailableError,
-                         TimedOutError, TooManyRequestsError, TransientFailureError,
-                         UnableToConnectToRobotError, UnauthenticatedError, UnimplementedError,
-                         UnknownDnsNameError)
+                         ProxyConnectionError, ProtobufDecodeError, ResponseTooLargeError,
+                         RetryableUnavailableError, RpcError, ServiceFailedDuringExecutionError,
+                         ServiceUnavailableError, TimedOutError, TooManyRequestsError,
+                         TransientFailureError, UnableToConnectToRobotError, UnauthenticatedError,
+                         UnimplementedError, UnknownDnsNameError)
 
 TransportError = grpc.RpcError
 
@@ -141,6 +141,10 @@ def translate_exception(rpc_error):
             return ResponseTooLargeError(rpc_error, ResponseTooLargeError.__doc__)
     elif code is grpc.StatusCode.UNAUTHENTICATED:
         return UnauthenticatedError(rpc_error, UnauthenticatedError.__doc__)
+
+    if code is grpc.StatusCode.INTERNAL:
+        if "deserializing" in details:
+            return ProtobufDecodeError(rpc_error, ProtobufDecodeError.__doc__)
 
     debug = rpc_error.debug_error_string()
     if debug is not None:

--- a/python/bosdyn-client/src/bosdyn/client/exceptions.py
+++ b/python/bosdyn-client/src/bosdyn/client/exceptions.py
@@ -121,6 +121,10 @@ class UnableToConnectToRobotError(RetryableRpcError):
     """The robot may be offline or otherwise unreachable."""
 
 
+class ProtobufDecodeError(RetryableRpcError):
+    """The message cannot be deserialized when the resource is busy"""
+
+
 class RetryableUnavailableError(UnableToConnectToRobotError):
     """Service unavailable or channel reset. Likely transient and can be resolved by retrying."""
 


### PR DESCRIPTION
In our application code, using AsyncTask and updating the robot info in the loop, sometimes DecodeError has been shown in the log, like

```
[grpc._common][ERROR] 2025-01-24 02:17:56,607: Exception deserializing message!
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/grpc/_common.py", line 89, in _transform
    return transformer(message)                                  
google.protobuf.message.DecodeError: Error parsing message with type 'bosdyn.api.RobotStateResponse'
```

then, nothing was updated, and our code hung.

I investigated and found that [this line](https://github.com/boston-dynamics/spot-sdk/blob/665de1bc1467c86e97cca9df905aa6e9a2c0a5a8/python/bosdyn-client/src/bosdyn/client/channel.py#L145) doesn't finish when this DecodeError occurs. So, I fixed it to catch it in this PR. 

I've already reported this case as 00033849 to BostonDynamics support.

We deploy our application to Spot EAP2.