### PR TITLE
Compute sin(acos(x)) as sqrt(1-dot*dot), which is faster.

### DIFF
--- a/python/bosdyn-client/src/bosdyn/client/math_helpers.py
+++ b/python/bosdyn-client/src/bosdyn/client/math_helpers.py
@@ -996,7 +996,7 @@ class Quat(object):
             theta_0 = math.acos(dot)  # theta_0 = angle between input vectors
             theta = theta_0 * fraction  # theta = angle between v0 and result
             sin_theta = math.sin(theta)  # compute this value only once
-            sin_theta_0 = math.sin(theta_0)  # compute this value only once
+            sin_theta_0 = math.sqrt(1.0 - dot*dot)  # compute this value only once
 
             s0 = math.cos(
                 theta) - dot * sin_theta / sin_theta_0  # == sin(theta_0 - theta) / sin(theta_0)


### PR DESCRIPTION
Notice that despite the subtraction "1-dot*dot" there is no significant loss of accuracy here, even for small angles where "dot" is near 1. This is because our knowledge of the angle from "dot (i.e. cos(theta)) is already limited by the floating representation error near 1, which is 2^-23 (1.1e-7) for single and 2^-52 (2.2e-16) for double precision.

The following program tabulates the relative error of the two formulas, evaluated in single precision, compared to evaluating the original formula in double precsion:

https://godbolt.org/z/qrzWcd43c