### PR TITLE
Bugfix: missing BosdynNavigateToAnchor field in node-types

### DIFF
--- a/protos/bosdyn/api/mission/nodes.proto
+++ b/protos/bosdyn/api/mission/nodes.proto
@@ -74,6 +74,7 @@ message Node {
         FormatBlackboard format_blackboard = 26;
         ConstantResult constant_result = 27;
         BosdynNavigateRoute bosdyn_navigate_route = 29;
+        BosdynNavigateToAnchor bosdyn_navigate_to_anchor = 65;
         BosdynNavigateTo bosdyn_navigate_to = 30;
         BosdynGraphNavState bosdyn_graph_nav_state = 31;
         BosdynGraphNavLocalize bosdyn_graph_nav_localize = 32;


### PR DESCRIPTION
The BosdynNavigateToAnchor action-node is mentioned in the Doku (https://dev.bostondynamics.com/docs/concepts/autonomy/missions_service) and it exists in nodes.proto but was forgotten (i suppose) to be added to the Node.type options. Therefore SDK Users cant use this feature in a behaviour tree:

nodes_pb2.Node().bosdyn_navigate_to_anchor